### PR TITLE
Add IAM Instance Profile as extra specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ To this end, this provider supports the following extra specs schema:
             "type": "string",
             "description": "The name of the Key Pair to use for the instance."
         },
+        "iam_instance_profile": {
+            "type": "string",
+            "description": "The ARN of the IAM instance profile to use for the instance."
+        },
         "iops": {
             "type": "integer",
             "description": "Specifies the number of IOPS (Input/Output Operations Per Second) provisioned for the volume. Required for io1 and io2 volumes. Optional for gp3 volumes."
@@ -183,6 +187,7 @@ An example extra specs json would look like this:
 {
     "subnet_id":"subnet-0e7a29d5cf6e54789",
     "ssh_key_name":"Garm-test",
+    "iam_instance_profile": "arn:aws:iam::123456789012:instance-profile/application_abc/component_xyz/Webserver",
     "iops": 3000,
     "throughput": 200,
     "volume_size": 50,
@@ -205,7 +210,7 @@ An example extra specs json would look like this:
 }
 ```
 
-*NOTE*: The `extra_context` spec adds a map of key/value pairs that may be expected in the `runner_install_template`.
+> **NOTE**: The `extra_context` spec adds a map of key/value pairs that may be expected in the `runner_install_template`.
 The `runner_install_template` allows us to completely override the script that installs and starts the runner. In the example above, I have added a copy of the current template from `garm-provider-common`, with the adition of:
 
 ```bash
@@ -216,7 +221,11 @@ export PATH=$PATH:/usr/local/go/bin
 {{- end }}
 ```
 
-*NOTE*: `runner_install_template` is a [golang template](https://pkg.go.dev/text/template), which is used to install the runner. An example on how you can extend the currently existing template with a function that downloads, extracts and installs Go on the runner is provided above.
+> **NOTE**: `runner_install_template` is a [golang template](https://pkg.go.dev/text/template), which is used to install the runner. An example on how you can extend the currently existing template with a function that downloads, extracts and installs Go on the runner is provided above.
+
+#### **Warnings Regarding IAM Instance Profiles**
+
+When configuring Garm to use [IAM Instance Profiles](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile) for your AWS runners, it’s important to be aware of the potential security implications. IAM Instance Profiles allow the instances to assume a role with permissions that can be broadly scoped, potentially granting more access than intended. Ensure that the IAM roles associated with your instance profiles adhere to the principle of least privilege, granting only the necessary permissions required for the runners to function. This setup is recommended only for private GitHub repositories, as using it with public repositories can expose your AWS environment to additional risks. Public repositories might inadvertently allow unauthorized access to your IAM credentials or resources. Therefore, use IAM Instance Profiles with public repositories at your own risk, and consider using alternative methods to securely manage credentials and permissions. Additionally, monitor and audit the actions performed by the instances regularly to ensure no unintended access to your AWS resources occurs.
 
 To set it on an existing pool, simply run:
 

--- a/internal/client/aws.go
+++ b/internal/client/aws.go
@@ -244,14 +244,15 @@ func (a *AwsCli) CreateRunningInstance(ctx context.Context, spec *spec.RunnerSpe
 	}
 
 	resp, err := a.client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:          aws.String(spec.BootstrapParams.Image),
-		InstanceType:     types.InstanceType(spec.BootstrapParams.Flavor),
-		MaxCount:         aws.Int32(1),
-		MinCount:         aws.Int32(1),
-		SubnetId:         aws.String(spec.SubnetID),
-		SecurityGroupIds: spec.SecurityGroupIds,
-		UserData:         aws.String(udata),
-		KeyName:          spec.SSHKeyName,
+		ImageId:            aws.String(spec.BootstrapParams.Image),
+		InstanceType:       types.InstanceType(spec.BootstrapParams.Flavor),
+		MaxCount:           aws.Int32(1),
+		MinCount:           aws.Int32(1),
+		SubnetId:           aws.String(spec.SubnetID),
+		SecurityGroupIds:   spec.SecurityGroupIds,
+		UserData:           aws.String(udata),
+		KeyName:            spec.SSHKeyName,
+		IamInstanceProfile: spec.IAMInstanceProfile,
 		BlockDeviceMappings: []types.BlockDeviceMapping{
 			{
 				DeviceName: aws.String("/dev/sda1"),

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -74,16 +74,17 @@ func newExtraSpecsFromBootstrapData(data params.BootstrapInstance) (*extraSpecs,
 }
 
 type extraSpecs struct {
-	SubnetID         *string          `json:"subnet_id,omitempty" jsonschema:"pattern=^subnet-[0-9a-fA-F]{17}$,description=The ID of the subnet formatted as subnet-xxxxxxxxxxxxxxxxx."`
-	SSHKeyName       *string          `json:"ssh_key_name,omitempty" jsonschema:"description=The name of the Key Pair to use for the instance."`
-	Iops             *int32           `json:"iops,omitempty" jsonschema:"description=Specifies the number of IOPS (Input/Output Operations Per Second) provisioned for the volume. Required for io1 and io2 volumes. Optional for gp3 volumes."`
-	Throughput       *int32           `json:"throughput,omitempty" jsonschema:"description=Specifies the throughput (MiB/s) provisioned for the volume. Valid only for gp3 volumes.,minimum=125,maximum=1000"`
-	VolumeSize       *int32           `json:"volume_size,omitempty" jsonschema:"description=Specifies the size of the volume in GiB. Required unless a snapshot ID is provided."`
-	VolumeType       types.VolumeType `json:"volume_type,omitempty" jsonschema:"enum=gp2,enum=gp3,enum=io1,enum=io2,enum=st1,enum=sc1,enum=standard,description=Specifies the EBS volume type."`
-	SecurityGroupIds []string         `json:"security_group_ids,omitempty" jsonschema:"description=The security group IDs to associate with the instance. Default: Amazon EC2 uses the default security group."`
-	DisableUpdates   *bool            `json:"disable_updates,omitempty" jsonschema:"description=Disable automatic updates on the VM."`
-	EnableBootDebug  *bool            `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM."`
-	ExtraPackages    []string         `json:"extra_packages,omitempty" jsonschema:"description=Extra packages to install on the VM."`
+	SubnetID           *string          `json:"subnet_id,omitempty" jsonschema:"pattern=^subnet-[0-9a-fA-F]{17}$,description=The ID of the subnet formatted as subnet-xxxxxxxxxxxxxxxxx."`
+	SSHKeyName         *string          `json:"ssh_key_name,omitempty" jsonschema:"description=The name of the Key Pair to use for the instance."`
+	IAMInstanceProfile *string          `json:"iam_instance_profile,omitempty jsonschema:"description=The IAM instance profile to associate with the instance."`
+	Iops               *int32           `json:"iops,omitempty" jsonschema:"description=Specifies the number of IOPS (Input/Output Operations Per Second) provisioned for the volume. Required for io1 and io2 volumes. Optional for gp3 volumes."`
+	Throughput         *int32           `json:"throughput,omitempty" jsonschema:"description=Specifies the throughput (MiB/s) provisioned for the volume. Valid only for gp3 volumes.,minimum=125,maximum=1000"`
+	VolumeSize         *int32           `json:"volume_size,omitempty" jsonschema:"description=Specifies the size of the volume in GiB. Required unless a snapshot ID is provided."`
+	VolumeType         types.VolumeType `json:"volume_type,omitempty" jsonschema:"enum=gp2,enum=gp3,enum=io1,enum=io2,enum=st1,enum=sc1,enum=standard,description=Specifies the EBS volume type."`
+	SecurityGroupIds   []string         `json:"security_group_ids,omitempty" jsonschema:"description=The security group IDs to associate with the instance. Default: Amazon EC2 uses the default security group."`
+	DisableUpdates     *bool            `json:"disable_updates,omitempty" jsonschema:"description=Disable automatic updates on the VM."`
+	EnableBootDebug    *bool            `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM."`
+	ExtraPackages      []string         `json:"extra_packages,omitempty" jsonschema:"description=Extra packages to install on the VM."`
 	cloudconfig.CloudConfigSpec
 }
 
@@ -117,20 +118,21 @@ func GetRunnerSpecFromBootstrapParams(cfg *config.Config, data params.BootstrapI
 }
 
 type RunnerSpec struct {
-	Region           string
-	DisableUpdates   bool
-	ExtraPackages    []string
-	EnableBootDebug  bool
-	Tools            params.RunnerApplicationDownload
-	BootstrapParams  params.BootstrapInstance
-	SecurityGroupIds []string
-	SubnetID         string
-	SSHKeyName       *string
-	Iops             *int32
-	Throughput       *int32
-	VolumeSize       *int32
-	VolumeType       types.VolumeType
-	ControllerID     string
+	Region             string
+	DisableUpdates     bool
+	ExtraPackages      []string
+	EnableBootDebug    bool
+	Tools              params.RunnerApplicationDownload
+	BootstrapParams    params.BootstrapInstance
+	SecurityGroupIds   []string
+	SubnetID           string
+	SSHKeyName         *string
+	IAMInstanceProfile *types.IamInstanceProfileSpecification
+	Iops               *int32
+	Throughput         *int32
+	VolumeSize         *int32
+	VolumeType         types.VolumeType
+	ControllerID       string
 }
 
 func (r *RunnerSpec) Validate() error {
@@ -234,6 +236,12 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 
 	if extraSpecs.EnableBootDebug != nil {
 		r.EnableBootDebug = *extraSpecs.EnableBootDebug
+	}
+
+	if extraSpecs.IAMInstanceProfile != nil {
+		r.IAMInstanceProfile = &types.IamInstanceProfileSpecification{
+			Arn: extraSpecs.IAMInstanceProfile,
+		}
 	}
 }
 


### PR DESCRIPTION
- Adds the option to add [IAM Instance Profile](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile) as extra-specs to the instance
- Updates `README.md` with **Warnings Regarding the use of IAM Instance Profiles**

Fixes #12 