### PR TITLE
Make session token optional

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,10 +85,6 @@ func (c StaticCredentials) Validate() error {
 		return fmt.Errorf("missing secret_access_key")
 	}
 
-	if c.SessionToken == "" {
-		return fmt.Errorf("missing session_token")
-	}
-
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -159,7 +159,7 @@ func TestCredentialsValidate(t *testing.T) {
 					SessionToken:    "",
 				},
 			},
-			errString: "missing session_token",
+			errString: "",
 		},
 	}
 


### PR DESCRIPTION
Session token is optional. This change removes the check for an empty session token option.