### PR TITLE
[WIP] Add extra-specs option to add SecurityGroups to the runner

### DIFF
--- a/internal/client/aws.go
+++ b/internal/client/aws.go
@@ -244,13 +244,14 @@ func (a *AwsCli) CreateRunningInstance(ctx context.Context, spec *spec.RunnerSpe
 	}
 
 	resp, err := a.client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String(spec.BootstrapParams.Image),
-		InstanceType: types.InstanceType(spec.BootstrapParams.Flavor),
-		MaxCount:     aws.Int32(1),
-		MinCount:     aws.Int32(1),
-		SubnetId:     aws.String(spec.SubnetID),
-		UserData:     aws.String(udata),
-		KeyName:      spec.SSHKeyName,
+		ImageId:          aws.String(spec.BootstrapParams.Image),
+		InstanceType:     types.InstanceType(spec.BootstrapParams.Flavor),
+		MaxCount:         aws.Int32(1),
+		MinCount:         aws.Int32(1),
+		SubnetId:         aws.String(spec.SubnetID),
+		SecurityGroupIds: spec.SecurityGroupIds,
+		UserData:         aws.String(udata),
+		KeyName:          spec.SSHKeyName,
 		TagSpecifications: []types.TagSpecification{
 			{
 				ResourceType: types.ResourceTypeInstance,

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -73,11 +73,12 @@ func newExtraSpecsFromBootstrapData(data params.BootstrapInstance) (*extraSpecs,
 }
 
 type extraSpecs struct {
-	SubnetID        *string  `json:"subnet_id,omitempty" jsonschema:"pattern=^subnet-[0-9a-fA-F]{17}$"`
-	SSHKeyName      *string  `json:"ssh_key_name,omitempty" jsonschema:"description=The name of the Key Pair to use for the instance."`
-	DisableUpdates  *bool    `json:"disable_updates,omitempty" jsonschema:"description=Disable automatic updates on the VM."`
-	EnableBootDebug *bool    `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM"`
-	ExtraPackages   []string `json:"extra_packages,omitempty" jsonschema:"description=Extra packages to install on the VM"`
+	SubnetID         *string  `json:"subnet_id,omitempty" jsonschema:"pattern=^subnet-[0-9a-fA-F]{17}$"`
+	SSHKeyName       *string  `json:"ssh_key_name,omitempty" jsonschema:"description=The name of the Key Pair to use for the instance."`
+	SecurityGroupIds []string `json:"security_group_ids,omitempty" jsonschema:"description=The security groups IDs to associate with the instance. Default: Amazon EC2 uses the default security group."`
+	DisableUpdates   *bool    `json:"disable_updates,omitempty" jsonschema:"description=Disable automatic updates on the VM."`
+	EnableBootDebug  *bool    `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM"`
+	ExtraPackages    []string `json:"extra_packages,omitempty" jsonschema:"description=Extra packages to install on the VM"`
 	// The Cloudconfig struct from common package
 	cloudconfig.CloudConfigSpec
 }
@@ -112,15 +113,16 @@ func GetRunnerSpecFromBootstrapParams(cfg *config.Config, data params.BootstrapI
 }
 
 type RunnerSpec struct {
-	Region          string
-	DisableUpdates  bool
-	ExtraPackages   []string
-	EnableBootDebug bool
-	Tools           params.RunnerApplicationDownload
-	BootstrapParams params.BootstrapInstance
-	SubnetID        string
-	SSHKeyName      *string
-	ControllerID    string
+	Region           string
+	DisableUpdates   bool
+	ExtraPackages    []string
+	EnableBootDebug  bool
+	Tools            params.RunnerApplicationDownload
+	BootstrapParams  params.BootstrapInstance
+	SecurityGroupIds []string
+	SubnetID         string
+	SSHKeyName       *string
+	ControllerID     string
 }
 
 func (r *RunnerSpec) Validate() error {
@@ -140,6 +142,10 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 
 	if extraSpecs.SSHKeyName != nil {
 		r.SSHKeyName = extraSpecs.SSHKeyName
+	}
+
+	if len(extraSpecs.SecurityGroupIds) > 0 {
+		r.SecurityGroupIds = extraSpecs.SecurityGroupIds
 	}
 
 	if extraSpecs.DisableUpdates != nil {


### PR DESCRIPTION
- adds extra-specs option to add Security Groups to the instances (until now it was used the default security group)