### PR TITLE
Gzip compress userdata on Linux

### DIFF
--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -284,7 +284,7 @@ func (r *RunnerSpec) ComposeUserData() (string, error) {
 }
 
 func maybeCompressUserdata(udata []byte, targetOS params.OSType) ([]byte, error) {
-	if len(udata) < 1<<24 {
+	if len(udata) < 1<<14 {
 		return udata, nil
 	}
 


### PR DESCRIPTION
cloud-init does not support zip compression but instead supports gzip compression. Trying to use zip compression confuses cloud-init.

I manually tested this as working:

```
root@ip-172-31-13-23:~# systemctl status actions.runner.sapslaj-garm-test.garm-test.service
● actions.runner.sapslaj-garm-test.garm-test.service - GitHub Actions Runner (actions.runner.sapslaj-garm-test.garm-test)
     Loaded: loaded (/etc/systemd/system/actions.runner.sapslaj-garm-test.garm-test.service; enabled; preset: enabled)
     Active: active (running) since Mon 2025-09-15 12:15:50 UTC; 1min 3s ago
   Main PID: 1791 (runsvc.sh)
      Tasks: 21 (limit: 2057)
     Memory: 47.5M (peak: 48.0M)
        CPU: 2.633s
     CGroup: /system.slice/actions.runner.sapslaj-garm-test.garm-test.service
             ├─1791 /bin/bash /home/runner/actions-runner/runsvc.sh
             ├─1794 ./externals/node20/bin/node ./bin/RunnerService.js
             └─1802 /home/runner/actions-runner/bin/Runner.Listener run --startuptype service

Sep 15 12:15:50 ip-172-31-13-23 systemd[1]: Started actions.runner.sapslaj-garm-test.garm-test.service - GitHub Actions Runner (actions.run>
Sep 15 12:15:50 ip-172-31-13-23 runsvc.sh[1791]: .path=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/g>
Sep 15 12:15:50 ip-172-31-13-23 runsvc.sh[1794]: Starting Runner listener with startup type: service
Sep 15 12:15:50 ip-172-31-13-23 runsvc.sh[1794]: Started listener process, pid: 1802
Sep 15 12:15:50 ip-172-31-13-23 runsvc.sh[1794]: Started running service
Sep 15 12:15:52 ip-172-31-13-23 runsvc.sh[1794]: √ Connected to GitHub
Sep 15 12:15:52 ip-172-31-13-23 runsvc.sh[1794]: Current runner version: '2.328.0'
Sep 15 12:15:52 ip-172-31-13-23 runsvc.sh[1794]: 2025-09-15 12:15:52Z: Listening for Jobs
root@ip-172-31-13-23:~# file /var/lib/cloud/instance/user-data.txt
/var/lib/cloud/instance/user-data.txt: gzip compressed data, original size modulo 2^32 7353
```

<img width="999" height="920" alt="image" src="https://github.com/user-attachments/assets/f2daca06-deaf-4de6-b132-4e24f2c014d6" />

This doesn't close the feature request in #27 but it at least fixes the underlying issue of not being able to spin up Linux instances.